### PR TITLE
Conform with strict provenance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ alloc = []
 i_know_what_im_doing = []
 
 [dependencies]
+sptr = { version = "0.3", optional = true }
 
 [dev-dependencies]
 rand = "0.8.4"

--- a/src/sptr.rs
+++ b/src/sptr.rs
@@ -1,0 +1,26 @@
+pub trait Strict {
+  fn addr(self) -> usize;
+  fn expose_addr(self) -> usize;
+  fn with_addr(self, addr: usize) -> Self;
+}
+
+macro_rules! impl_strict {
+  ($($t:ty),*) => {
+    $(impl<T> Strict for $t {
+      #[inline]
+      fn addr(self) -> usize { self as usize }
+      #[inline]
+      fn expose_addr(self) -> usize { self as usize }
+      #[inline]
+      fn with_addr(self, addr: usize) -> Self {
+        // Implementation taken from the `sptr` crate.
+        let self_addr = self.addr() as isize;
+        let dest_addr = addr as isize;
+        let offset = dest_addr.wrapping_sub(self_addr);
+        self.cast::<u8>().wrapping_offset(offset).cast::<T>()
+      }
+    })*
+  };
+}
+
+impl_strict!(*const T, *mut T);


### PR DESCRIPTION
Previous version stored pointer as a `usize`, which causes warnings in Miri by default and error with `-Zmiri-strict-provenance`.

This version stores pointer directly and allows using proper strict provenance APIs with `sptr` feature. It potentially benefits optimizations and clarifies semantics of pointer-to-integer casts.

This PR also rewrites a couple of `Clone` implementations to be defined in terms of `Copy`.

Unfortunately, doing this introduced some semver-incompatible changes to the API:
- `pack()` now returns a `*mut T` instead of `usize`
- `unpack()` now takes a `*mut T` instead of `usize`

Considering this, I’m not sure whether it would be worthwhile to merge. Maybe adding new `pack_ptr()` / `unpack_ptr()` functions would work better?